### PR TITLE
Feature/reservation_release merge

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
             android:name=".activity.ReservationActivity"
             android:exported="true" />
         <activity
+            android:name=".activity.ReleaseActivity"
+            android:exported="true" />
+        <activity
             android:name=".activity.SettingsActivity"
             android:exported="true" />
     </application>

--- a/app/src/main/java/com/fcaputo/parkingapp/activity/ReleaseActivity.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/activity/ReleaseActivity.kt
@@ -1,0 +1,24 @@
+package com.fcaputo.parkingapp.activity
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.fcaputo.parkingapp.R
+import com.fcaputo.parkingapp.mvp.model.ReleaseModel
+import com.fcaputo.parkingapp.mvp.presenter.ReleasePresenter
+import com.fcaputo.parkingapp.mvp.view.ReleaseView
+
+class ReleaseActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_release)
+        ReleasePresenter(ReleaseModel(), ReleaseView(this))
+    }
+
+    companion object {
+        fun getIntent(activity: Activity?): Intent {
+            return Intent(activity as AppCompatActivity, ReleaseActivity::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/contract/HomeContract.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/contract/HomeContract.kt
@@ -2,14 +2,17 @@ package com.fcaputo.parkingapp.mvp.contract
 
 interface HomeContract {
     interface Presenter {
-        fun onSettingsClick()
-        fun onMakeReservationClick()
+        fun onSettingsPressed()
+        fun onMakeReservationPressed()
+        fun onReleasePressed()
     }
 
     interface View {
-        fun onSettingsButton(onClick: () -> Unit)
-        fun onMakeReservationButton(onClick: () -> Unit)
+        fun onSettingsButton(onPressed: () -> Unit)
+        fun onMakeReservationButton(onPressed: () -> Unit)
+        fun onReleaseButton(onPressed: () -> Unit)
         fun navigateToSettings()
         fun navigateToMakeReservation()
+        fun navigateToReleaseSpot()
     }
 }

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/contract/ReleaseContract.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/contract/ReleaseContract.kt
@@ -1,0 +1,30 @@
+package com.fcaputo.parkingapp.mvp.contract
+
+import com.fcaputo.parkingapp.utils.validation.ValidationResult
+
+interface ReleaseContract {
+    interface Model {
+        fun validateData(parkingNumber: Int, securityCode: Int): ValidationResult
+        fun deleteReservation(parkingNumber: Int, securityCode: Int)
+    }
+
+    interface Presenter {
+        fun onReleasePressed()
+        fun onReleaseConfirmed()
+    }
+
+    interface View {
+        fun onReleaseButton(onPressed: () -> Unit)
+        fun getEditTextsContents(): List<String>
+        fun showIncompleteFieldError()
+        fun showConfirmationDialog(onConfirmed: () -> Unit)
+        fun getParkingNumber(): String
+        fun getSecurityCode(): String
+        fun showSuccessMessage()
+        fun clear()
+        fun showZeroSpotError()
+        fun showOutOfRangeSpotError()
+        fun showReservationNotFoundError()
+        fun showGenericError()
+    }
+}

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/model/ParkingData.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/model/ParkingData.kt
@@ -1,0 +1,7 @@
+package com.fcaputo.parkingapp.mvp.model
+
+import com.fcaputo.parkingapp.entity.Reservation
+
+object ParkingData {
+    val reservations = mutableListOf<Reservation>()
+}

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/model/ReleaseModel.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/model/ReleaseModel.kt
@@ -1,0 +1,34 @@
+package com.fcaputo.parkingapp.mvp.model
+
+import com.fcaputo.parkingapp.mvp.contract.ReleaseContract
+import com.fcaputo.parkingapp.utils.Constants.ZERO_INT
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType.SPOT_IS_ZERO
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType.SPOT_IS_OUT_OF_RANGE
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType.RESERVATION_NOT_FOUND
+import com.fcaputo.parkingapp.utils.validation.ValidationResult
+
+class ReleaseModel : ReleaseContract.Model {
+    private val reservations = ParkingData.reservations
+
+    override fun validateData(parkingNumber: Int, securityCode: Int): ValidationResult {
+        return if (parkingNumber == ZERO_INT) {
+            ValidationResult(isSuccess = false, error = SPOT_IS_ZERO)
+        } else if (parkingNumber > getParkingLotSize()) {
+            ValidationResult(isSuccess = false, error = SPOT_IS_OUT_OF_RANGE)
+        } else if (!reservationExists(parkingNumber, securityCode)) {
+            ValidationResult(isSuccess = false, error = RESERVATION_NOT_FOUND)
+        } else {
+            ValidationResult(isSuccess = true)
+        }
+    }
+
+    private fun reservationExists(parkingNumber: Int, securityCode: Int): Boolean {
+        return reservations.any { it.parkingLot == parkingNumber && it.securityCode == securityCode }
+    }
+
+    private fun getParkingLotSize() = ParkingSettings.size
+
+    override fun deleteReservation(parkingNumber: Int, securityCode: Int) {
+        reservations.removeIf { it.parkingLot == parkingNumber && it.securityCode == securityCode }
+    }
+}

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/model/ReservationModel.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/model/ReservationModel.kt
@@ -8,15 +8,13 @@ import com.fcaputo.parkingapp.utils.validation.ValidationResult
 import java.util.Calendar
 
 class ReservationModel : ReservationContract.Model {
-    private val reservations: MutableList<Reservation> = mutableListOf()
-
     override fun getParkingLotSize() = ParkingSettings.size
 
     override fun storeReservation(reservation: Reservation) {
-        reservations.add(reservation)
+        ParkingData.reservations.add(reservation)
     }
 
-    override fun getReservations(): List<Reservation> = reservations.toList()
+    override fun getReservations(): List<Reservation> = ParkingData.reservations.toList()
 
     override fun validateData(startDate: Calendar, endDate: Calendar, parkingSpot: Int): ValidationResult {
         val today = Calendar.getInstance()
@@ -38,7 +36,7 @@ class ReservationModel : ReservationContract.Model {
         }
     }
 
-    private fun getReservationsByParkingSpot(spotNumber: Int) = reservations.filter{ it.parkingLot == spotNumber }.toList()
+    private fun getReservationsByParkingSpot(spotNumber: Int) = getReservations().filter{ it.parkingLot == spotNumber }.toList()
 
     private fun isSpotAvailable(startDate: Calendar, endDate: Calendar, spotReservations: List<Reservation>): Boolean {
         return spotReservations.all { !datesOverlap(startDate, endDate, it) }

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/presenter/HomePresenter.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/presenter/HomePresenter.kt
@@ -4,15 +4,20 @@ import com.fcaputo.parkingapp.mvp.contract.HomeContract
 
 class HomePresenter(private val view: HomeContract.View) : HomeContract.Presenter {
     init {
-        view.onSettingsButton { onSettingsClick() }
-        view.onMakeReservationButton { onMakeReservationClick() }
+        view.onSettingsButton { onSettingsPressed() }
+        view.onMakeReservationButton { onMakeReservationPressed() }
+        view.onReleaseButton { onReleasePressed() }
     }
 
-    override fun onSettingsClick() {
+    override fun onSettingsPressed() {
         view.navigateToSettings()
     }
 
-    override fun onMakeReservationClick() {
+    override fun onMakeReservationPressed() {
         view.navigateToMakeReservation()
+    }
+
+    override fun onReleasePressed() {
+        view.navigateToReleaseSpot()
     }
 }

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/presenter/ReleasePresenter.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/presenter/ReleasePresenter.kt
@@ -1,0 +1,55 @@
+package com.fcaputo.parkingapp.mvp.presenter
+
+import com.fcaputo.parkingapp.mvp.contract.ReleaseContract
+import com.fcaputo.parkingapp.utils.hasData
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType.INCOMPLETE_FIELD
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType.SPOT_IS_ZERO
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType.SPOT_IS_OUT_OF_RANGE
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType.RESERVATION_NOT_FOUND
+
+class ReleasePresenter(private val model: ReleaseContract.Model, private val view: ReleaseContract.View) : ReleaseContract.Presenter {
+
+    init {
+        view.onReleaseButton { onReleasePressed() }
+    }
+
+    override fun onReleasePressed() {
+        if(!isFormComplete()) {
+            showError(INCOMPLETE_FIELD)
+            return
+        }
+
+        val parkingNumber = view.getParkingNumber().toInt()
+        val securityCode = view.getSecurityCode().toInt()
+
+        val validationResult = model.validateData(parkingNumber, securityCode)
+        if (validationResult.isSuccess) {
+            view.showConfirmationDialog { onReleaseConfirmed() }
+        } else {
+            validationResult.error?.let { showError(it) }
+        }
+    }
+
+    override fun onReleaseConfirmed() {
+        val parkingNumber = view.getParkingNumber().toInt()
+        val securityCode = view.getSecurityCode().toInt()
+
+        model.deleteReservation(parkingNumber, securityCode)
+        view.showSuccessMessage()
+        view.clear()
+    }
+
+
+    private fun isFormComplete(): Boolean = view.getEditTextsContents().all { it.hasData() }
+
+    private fun showError(error: ValidationErrorType) {
+        when (error) {
+            INCOMPLETE_FIELD -> view.showIncompleteFieldError()
+            SPOT_IS_ZERO -> view.showZeroSpotError()
+            SPOT_IS_OUT_OF_RANGE -> view.showOutOfRangeSpotError()
+            RESERVATION_NOT_FOUND -> view.showReservationNotFoundError()
+            else -> view.showGenericError()
+        }
+    }
+}

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/view/HomeView.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/view/HomeView.kt
@@ -1,6 +1,7 @@
 package com.fcaputo.parkingapp.mvp.view
 
 import android.app.Activity
+import com.fcaputo.parkingapp.activity.ReleaseActivity
 import com.fcaputo.parkingapp.activity.ReservationActivity
 import com.fcaputo.parkingapp.activity.SettingsActivity
 import com.fcaputo.parkingapp.databinding.ActivityHomeBinding
@@ -14,12 +15,16 @@ class HomeView(activity: Activity) : ActivityView(activity), HomeContract.View {
         activity.setContentView(binding.root)
     }
 
-    override fun onSettingsButton(onClick: () -> Unit) {
-        binding.btnSettings.setOnClickListener { onClick() }
+    override fun onSettingsButton(onPressed: () -> Unit) {
+        binding.btnSettings.setOnClickListener { onPressed() }
     }
 
-    override fun onMakeReservationButton(onClick: () -> Unit) {
-        binding.btnReservation.setOnClickListener { onClick() }
+    override fun onMakeReservationButton(onPressed: () -> Unit) {
+        binding.btnReservation.setOnClickListener { onPressed() }
+    }
+
+    override fun onReleaseButton(onPressed: () -> Unit) {
+        binding.btnRelease.setOnClickListener { onPressed() }
     }
 
     override fun navigateToSettings() {
@@ -28,5 +33,9 @@ class HomeView(activity: Activity) : ActivityView(activity), HomeContract.View {
 
     override fun navigateToMakeReservation() {
         activity?.startActivity(ReservationActivity.getIntent(activity))
+    }
+
+    override fun navigateToReleaseSpot() {
+        activity?.startActivity(ReleaseActivity.getIntent(activity))
     }
 }

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/view/ReleaseView.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/view/ReleaseView.kt
@@ -1,0 +1,86 @@
+package com.fcaputo.parkingapp.mvp.view
+
+import android.app.Activity
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
+import com.fcaputo.parkingapp.R
+import com.fcaputo.parkingapp.databinding.ActivityReleaseBinding
+import com.fcaputo.parkingapp.mvp.contract.ReleaseContract
+import com.fcaputo.parkingapp.mvp.view.base.ActivityView
+import com.fcaputo.parkingapp.mvp.view.utils.AlertDialogFactory
+
+class ReleaseView(activity: Activity) : ActivityView(activity), ReleaseContract.View {
+    private var binding: ActivityReleaseBinding = ActivityReleaseBinding.inflate(activity.layoutInflater)
+
+    init {
+        activity.setContentView(binding.root)
+    }
+
+    override fun onReleaseButton(onPressed: () -> Unit) {
+        binding.btnRelease.setOnClickListener { onPressed() }
+    }
+
+    override fun getEditTextsContents(): List<String> {
+        return listOf(binding.etParkingNumber.text.toString(),
+            binding.etSecurityCode.text.toString()
+        )
+    }
+
+    override fun showIncompleteFieldError() {
+        showErrorMessage(R.string.error_incomplete_field_title, R.string.error_incomplete_field_msg)
+    }
+
+    override fun showConfirmationDialog(onConfirmed: () -> Unit) {
+        AlertDialogFactory.showDialog(
+            activity as AppCompatActivity,
+            R.string.release_confirmation_title,
+            R.string.release_confirmation_msg,
+            R.string.release_confirmation_yes,
+            R.string.release_confirmation_no
+        ) { onConfirmed() }
+    }
+
+    override fun getParkingNumber(): String = binding.etParkingNumber.text.toString()
+
+    override fun getSecurityCode(): String = binding.etSecurityCode.text.toString()
+
+    override fun showSuccessMessage() {
+        AlertDialogFactory.showDialog(
+            activity as AppCompatActivity,
+            R.string.release_success_title,
+            R.string.release_success_msg,
+            R.string.success_dialog_ok_text
+        )
+    }
+
+    override fun clear() {
+        binding.etParkingNumber.text?.clear()
+        binding.etSecurityCode.text?.clear()
+        binding.root.requestFocus()
+    }
+
+    override fun showZeroSpotError() {
+        showErrorMessage(R.string.error_invalidSpot_title, R.string.error_spotNumberIsZero_msg)
+    }
+
+    override fun showOutOfRangeSpotError() {
+        showErrorMessage(R.string.error_invalidSpot_title, R.string.error_release_outOfRangeSpot_msg)
+    }
+
+    override fun showReservationNotFoundError() {
+        showErrorMessage(R.string.error_release_reservationNotFound_title, R.string.error_release_reservationNotFound_msg)
+    }
+
+    override fun showGenericError() {
+        showErrorMessage(R.string.error_others_title, R.string.error_others_msg)
+    }
+
+    private fun showErrorMessage(@StringRes titleId: Int, @StringRes messageId: Int) {
+        AlertDialogFactory.showDialog(
+            activity as AppCompatActivity,
+            titleId,
+            messageId,
+            R.string.error_dialog_got_it_text
+        )
+    }
+}

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/view/ReservationView.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/view/ReservationView.kt
@@ -116,15 +116,15 @@ class ReservationView(activity: Activity) : ActivityView(activity), ReservationC
     }
 
     override fun showOutOfRangeSpotError() {
-        showErrorMessage(R.string.error_reservation_invalidSpot_title, R.string.error_reservation_outOfRangeSpot_msg)
+        showErrorMessage(R.string.error_invalidSpot_title, R.string.error_reservation_outOfRangeSpot_msg)
     }
 
     override fun showZeroSpotError() {
-        showErrorMessage(R.string.error_reservation_invalidSpot_title, R.string.error_reservation_spotNumberIsZero_msg)
+        showErrorMessage(R.string.error_invalidSpot_title, R.string.error_spotNumberIsZero_msg)
     }
 
     override fun showUnavailableSpotError() {
-        showErrorMessage(R.string.error_reservation_invalidSpot_title, R.string.error_reservation_unavailableSpot_msg)
+        showErrorMessage(R.string.error_invalidSpot_title, R.string.error_reservation_unavailableSpot_msg)
     }
 
     override fun showSizeNotSetError() {

--- a/app/src/main/java/com/fcaputo/parkingapp/mvp/view/utils/AlertDialogFactory.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/mvp/view/utils/AlertDialogFactory.kt
@@ -1,0 +1,29 @@
+package com.fcaputo.parkingapp.mvp.view.utils
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+object AlertDialogFactory {
+    fun showDialog(
+        context: Context,
+        @StringRes titleId: Int,
+        @StringRes messageId: Int,
+        @StringRes positiveTextId: Int,
+        @StringRes negativeTextId: Int? = null,
+        onConfirmed: (() -> Unit)? = null
+    ) {
+        val builder = MaterialAlertDialogBuilder(context)
+            .setTitle(titleId)
+            .setMessage(messageId)
+
+        if (negativeTextId != null && onConfirmed != null) {
+            builder.setPositiveButton(positiveTextId) { _, _ -> onConfirmed() }
+                .setNegativeButton(negativeTextId, null)
+        } else {
+            builder.setPositiveButton(positiveTextId, null)
+        }
+
+        builder.show()
+    }
+}

--- a/app/src/main/java/com/fcaputo/parkingapp/utils/validation/ValidationErrorType.kt
+++ b/app/src/main/java/com/fcaputo/parkingapp/utils/validation/ValidationErrorType.kt
@@ -8,5 +8,6 @@ enum class ValidationErrorType {
     SPOT_IS_OUT_OF_RANGE,
     SPOT_IS_ZERO,
     SPOT_IS_UNAVAILABLE,
-    SIZE_NOT_SET
+    SIZE_NOT_SET,
+    RESERVATION_NOT_FOUND
 }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -25,11 +25,24 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/std_margin"
+        android:layout_marginBottom="@dimen/std_margin"
         android:text="@string/home_reservations_button"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/btnRelease"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btnSettings" />
+
+    <Button
+        android:id="@+id/btnRelease"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/home_release_button"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btnSettings" />
+        app:layout_constraintTop_toBottomOf="@id/btnReservation" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_release.xml
+++ b/app/src/main/res/layout/activity_release.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/std_margin"
+    android:focusableInTouchMode="true"
+    tools:context=".activity.ReleaseActivity">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/std_margin"
+        android:text="@string/release_activity_title"
+        android:textSize="@dimen/title_text_size"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_parking_number"
+        style="@style/TextInputLayoutTheme"
+        android:layout_height="wrap_content"
+        android:hint="@string/release_parking_spot"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        app:layout_constraintBottom_toTopOf="@id/til_security_code">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_parking_number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:maxLength="@string/numFields_maxLength" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_security_code"
+        style="@style/TextInputLayoutTheme"
+        android:layout_height="wrap_content"
+        android:hint="@string/release_security_code"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/til_parking_number">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_security_code"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:maxLength="@string/numFields_maxLength" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+
+    <Button
+        android:id="@+id/btnRelease"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/std_margin"
+        android:text="@string/release_delete_button"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/til_security_code" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_reservation.xml
+++ b/app/src/main/res/layout/activity_reservation.xml
@@ -102,7 +102,7 @@
         android:id="@+id/tilParkingLot"
         style="@style/TextInputLayoutTheme"
         android:layout_height="wrap_content"
-        android:hint="@string/reservation_parking_lot_number"
+        android:hint="@string/reservation_parking_spot_number"
         app:helperTextEnabled="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,13 +6,18 @@
     <string name="success_dialog_ok_text">OK</string>
     <string name="error_dialog_got_it_text">GOT IT</string>
     <string name="error_others_title">Error</string>
+    <string name="error_others_msg">There was an error. Please try again.</string>
     <string name="error_incomplete_field_title">Missing Fields</string>
     <string name="error_incomplete_field_msg">There are some missing fields.</string>
 
+    <string name="error_invalidSpot_title">Invalid Spot Number</string>
+    <string name="error_spotNumberIsZero_msg">Parking number must be greater than zero.</string>
+
     <!-- Home Screen -->
     <string name="home_title">Parking Reservation App</string>
-    <string name="home_settings_button">SETTINGS</string>
-    <string name="home_reservations_button">MAKE A RESERVATION</string>
+    <string name="home_settings_button">Settings</string>
+    <string name="home_reservations_button">Make a reservation</string>
+    <string name="home_release_button">Release a spot</string>
 
     <!-- Settings Screen -->
     <string name="settings_activity_title">Settings</string>
@@ -31,7 +36,7 @@
     <string name="reservation_start_time">Start Time</string>
     <string name="reservation_end_date">End Date</string>
     <string name="reservation_end_time">End Time</string>
-    <string name="reservation_parking_lot_number">Parking Lot</string>
+    <string name="reservation_parking_spot_number">Parking Spot</string>
     <string name="reservation_parking_lot_size_helper">Parking lot size: %1$s</string>
     <string name="reservation_security_code">Security Code</string>
     <string name="reservation_submit_res">Submit</string>
@@ -39,10 +44,8 @@
     <string name="error_reservation_invalidDate_title">Invalid Dates</string>
     <string name="error_reservation_unorderedDates_msg">End date must be greater than start date.</string>
     <string name="error_reservation_pastDates_msg">Both start and end dates must be future.</string>
-    <string name="error_reservation_invalidSpot_title">Invalid Spot Number</string>
     <string name="error_reservation_unavailableSpot_msg">The selected parking spot is not available in the selected date range. Please consider choosing another one.</string>
     <string name="error_reservation_outOfRangeSpot_msg"> Parking number must be lesser than the parking lot size.</string>
-    <string name="error_reservation_spotNumberIsZero_msg">Parking number must be greater than zero.</string>
     <string name="error_size_not_set_msg">Could not retrieve the parking lot size. Please be sure it is set and then retry.</string>
 
     <string name="reservation_success_title">Reservation confirmed</string>
@@ -50,5 +53,22 @@
     <string name="date_picker_tag">Date Picker</string>
     <string name="time_picker_tag">Time Picker</string>
 
-    <string name="navigation_settings">SETTINGS</string>
+    <!-- Release Screen -->
+    <string name="release_activity_title">Parking Spot Release</string>
+    <string name="release_parking_spot">Parking Spot</string>
+    <string name="release_security_code">Security Code</string>
+    <string name="release_delete_button">Release</string>
+
+    <string name="error_release_reservationNotFound_title">Reservation not found</string>
+    <string name="error_release_reservationNotFound_msg">No reservation was found with given spot number and security code.</string>
+    <string name="error_release_outOfRangeSpot_msg">Parking spot does not exist.</string>
+
+    <string name="release_confirmation_title">Releasing confirmation</string>
+    <string name="release_confirmation_msg">Are you sure you want to release this spot? This action cannot be undone.</string>
+    <string name="release_confirmation_yes">Yes</string>
+    <string name="release_confirmation_no">No</string>
+
+    <string name="release_success_title">Spot release confirmed</string>
+    <string name="release_success_msg">The spot was successfully released.</string>
+
 </resources>

--- a/app/src/test/java/com/fcaputo/parkingapp/model/ReleaseModelTest.kt
+++ b/app/src/test/java/com/fcaputo/parkingapp/model/ReleaseModelTest.kt
@@ -1,0 +1,144 @@
+package com.fcaputo.parkingapp.model
+
+import com.fcaputo.parkingapp.entity.Reservation
+import com.fcaputo.parkingapp.mvp.contract.ReleaseContract
+import com.fcaputo.parkingapp.mvp.model.ParkingData
+import com.fcaputo.parkingapp.mvp.model.ParkingSettings
+import com.fcaputo.parkingapp.mvp.model.ReleaseModel
+import com.fcaputo.parkingapp.utils.Constants.ZERO_INT
+import com.fcaputo.parkingapp.utils.getUtcCalendarInstance
+import com.fcaputo.parkingapp.utils.plusHours
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType.*
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+
+class ReleaseModelTest {
+    private lateinit var model: ReleaseContract.Model
+
+    @Before
+    fun setup() {
+        ParkingSettings.size = VALID_SIZE
+        ParkingData.reservations.clear()
+        model = ReleaseModel()
+    }
+
+    @Test
+    fun `when validating, if parkingNumber is zero, model returns corresponding error`() {
+        val result = model.validateData(ZERO_INT, SECURITY_CODE)
+        Assert.assertFalse(result.isSuccess)
+        Assert.assertEquals(SPOT_IS_ZERO, result.error)
+    }
+
+    @Test
+    fun `when validating, if parkingNumber is out of range, model returns corresponding error`() {
+        val result = model.validateData(OUT_OF_RANGE_SPOT, SECURITY_CODE)
+        Assert.assertFalse(result.isSuccess)
+        Assert.assertEquals(SPOT_IS_OUT_OF_RANGE, result.error)
+    }
+
+    @Test
+    fun `when validating, if both spot and code are incorrect, model returns corresponding error`() {
+        ParkingData.reservations.add(Reservation(
+            startDate = futureEarlierDate,
+            endDate = futureLaterDate,
+            parkingLot = FIRST_SPOT,
+            securityCode = SECURITY_CODE
+        ))
+        ParkingData.reservations.add(Reservation(
+            startDate = futureEarlierDate,
+            endDate = futureLaterDate,
+            parkingLot = SECOND_SPOT,
+            securityCode = SECOND_SECURITY_CODE
+        ))
+
+        val result = model.validateData(THIRD_SPOT, THIRD_SECURITY_CODE)
+        Assert.assertFalse(result.isSuccess)
+        Assert.assertEquals(RESERVATION_NOT_FOUND, result.error)
+    }
+
+    @Test
+    fun `when validating, if code is incorrect, model returns corresponding error`() {
+        ParkingData.reservations.add(Reservation(
+            startDate = futureEarlierDate,
+            endDate = futureLaterDate,
+            parkingLot = FIRST_SPOT,
+            securityCode = SECURITY_CODE
+        ))
+        ParkingData.reservations.add(Reservation(
+            startDate = futureEarlierDate,
+            endDate = futureLaterDate,
+            parkingLot = SECOND_SPOT,
+            securityCode = SECOND_SECURITY_CODE
+        ))
+
+        val result = model.validateData(SECOND_SPOT, THIRD_SECURITY_CODE)
+        Assert.assertFalse(result.isSuccess)
+        Assert.assertEquals(RESERVATION_NOT_FOUND, result.error)
+    }
+
+    @Test
+    fun `when validating, if both spot and code are correct, model returns success`() {
+        ParkingData.reservations.add(Reservation(
+            startDate = futureEarlierDate,
+            endDate = futureLaterDate,
+            parkingLot = FIRST_SPOT,
+            securityCode = SECURITY_CODE
+        ))
+        ParkingData.reservations.add(Reservation(
+            startDate = futureEarlierDate,
+            endDate = futureLaterDate,
+            parkingLot = SECOND_SPOT,
+            securityCode = SECOND_SECURITY_CODE
+        ))
+
+        val result = model.validateData(SECOND_SPOT, SECOND_SECURITY_CODE)
+        Assert.assertTrue(result.isSuccess)
+        Assert.assertNull(result.error)
+    }
+
+    @Test
+    fun `when given a correct spot and code combination, model releases the spot successfully`() {
+        ParkingData.reservations.add(
+            Reservation(
+                startDate = futureEarlierDate,
+                endDate = futureLaterDate,
+                parkingLot = FIRST_SPOT,
+                securityCode = SECURITY_CODE
+            )
+        )
+        ParkingData.reservations.add(
+            Reservation(
+                startDate = futureEarlierDate,
+                endDate = futureLaterDate,
+                parkingLot = SECOND_SPOT,
+                securityCode = SECOND_SECURITY_CODE
+            )
+        )
+
+        Assert.assertEquals(TWO_INT, ParkingData.reservations.size)
+        model.deleteReservation(SECOND_SPOT, SECOND_SECURITY_CODE)
+        Assert.assertEquals(ONE_INT, ParkingData.reservations.size)
+        Assert.assertFalse(ParkingData.reservations.any {
+            it.parkingLot == SECOND_SPOT && it.securityCode == SECOND_SECURITY_CODE
+        })
+    }
+
+        companion object {
+        const val SECURITY_CODE = 1234
+        const val SECOND_SECURITY_CODE = 9876
+        const val THIRD_SECURITY_CODE = 5555
+        const val VALID_SIZE = 100
+        const val OUT_OF_RANGE_SPOT = 999
+        const val FIRST_SPOT = 25
+        const val SECOND_SPOT = 31
+        const val THIRD_SPOT = 48
+
+        const val ONE_INT = 1
+        const val TWO_INT = 2
+
+        val futureEarlierDate: Calendar = getUtcCalendarInstance().plusHours(ONE_INT)
+        val futureLaterDate: Calendar = futureEarlierDate.plusHours(ONE_INT)
+    }
+}

--- a/app/src/test/java/com/fcaputo/parkingapp/presenter/HomePresenterTest.kt
+++ b/app/src/test/java/com/fcaputo/parkingapp/presenter/HomePresenterTest.kt
@@ -20,13 +20,13 @@ class HomePresenterTest {
 
     @Test
     fun `when Settings button is pressed, presenter redirects to Settings screen`(){
-        presenter.onSettingsClick()
+        presenter.onSettingsPressed()
         verify { view.navigateToSettings() }
     }
 
     @Test
     fun `when 'Make a Reservation' button is pressed, presenter redirects to Reservations screen`(){
-        presenter.onMakeReservationClick()
+        presenter.onMakeReservationPressed()
         verify { view.navigateToMakeReservation() }
     }
 

--- a/app/src/test/java/com/fcaputo/parkingapp/presenter/ReleasePresenterTest.kt
+++ b/app/src/test/java/com/fcaputo/parkingapp/presenter/ReleasePresenterTest.kt
@@ -1,0 +1,102 @@
+package com.fcaputo.parkingapp.presenter
+
+import com.fcaputo.parkingapp.mvp.contract.ReleaseContract
+import com.fcaputo.parkingapp.mvp.presenter.ReleasePresenter
+import com.fcaputo.parkingapp.utils.Constants.EMPTY_STRING
+import com.fcaputo.parkingapp.utils.validation.ValidationErrorType
+import com.fcaputo.parkingapp.utils.validation.ValidationResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Before
+import org.junit.Test
+
+class ReleasePresenterTest {
+    private lateinit var presenter: ReleaseContract.Presenter
+    private val view: ReleaseContract.View = mockk(relaxed = true)
+    private val model: ReleaseContract.Model = mockk(relaxed = true)
+
+    @Before
+    fun setup() {
+        presenter = ReleasePresenter(model, view)
+        verify { view.onReleaseButton(any()) }
+    }
+
+    @Test
+    fun `when release button is pressed, and form is incomplete, presenter raises an error`() {
+        every { view.getEditTextsContents() } returns listOf(EMPTY_STRING, EMPTY_STRING)
+
+        presenter.onReleasePressed()
+        verify { view.showIncompleteFieldError() }
+    }
+
+    @Test
+    fun `when release button is pressed, when validating, if an error occurs, presenter shows it`() {
+        every { view.getEditTextsContents() } returns listOf(SPOT_STRING, SECURITY_CODE_STRING)
+        every { view.getParkingNumber() } returns SPOT_STRING
+        every { view.getSecurityCode() } returns SECURITY_CODE_STRING
+        every { model.validateData(SPOT, SECURITY_CODE) } returns ValidationResult(isSuccess = false, error = ValidationErrorType.RESERVATION_NOT_FOUND)
+
+        presenter.onReleasePressed()
+        verifyOrder {
+            view.getParkingNumber()
+            view.getSecurityCode()
+            model.validateData(SPOT, SECURITY_CODE)
+            view.showReservationNotFoundError()
+        }
+    }
+
+    @Test
+    fun `when release button is pressed, when validating, if an unexpected error occurs, presenter shows a generic message`() {
+        every { view.getEditTextsContents() } returns listOf(SPOT_STRING, SECURITY_CODE_STRING)
+        every { view.getParkingNumber() } returns SPOT_STRING
+        every { view.getSecurityCode() } returns SECURITY_CODE_STRING
+        every { model.validateData(SPOT, SECURITY_CODE) } returns ValidationResult(isSuccess = false, error = ValidationErrorType.SIZE_NOT_SET)
+
+        presenter.onReleasePressed()
+        verifyOrder {
+            view.getParkingNumber()
+            view.getSecurityCode()
+            model.validateData(SPOT, SECURITY_CODE)
+            view.showGenericError()
+        }
+    }
+
+    @Test
+    fun `when release button is pressed, if data is correct, presenter shows confirmation dialog`() {
+        every { view.getParkingNumber() } returns SPOT_STRING
+        every { view.getSecurityCode() } returns SECURITY_CODE_STRING
+        every { model.validateData(SPOT, SECURITY_CODE) } returns ValidationResult(isSuccess = true)
+
+        presenter.onReleasePressed()
+        verifyOrder {
+            view.getParkingNumber()
+            view.getSecurityCode()
+            model.validateData(SPOT, SECURITY_CODE)
+            view.showConfirmationDialog(any())
+        }
+    }
+
+    @Test
+    fun `after user confirmation, presenter releases the spot`() {
+        every { view.getParkingNumber() } returns SPOT_STRING
+        every { view.getSecurityCode() } returns SECURITY_CODE_STRING
+
+        presenter.onReleaseConfirmed()
+        verifyOrder {
+            view.getParkingNumber()
+            view.getSecurityCode()
+            model.deleteReservation(SPOT, SECURITY_CODE)
+            view.showSuccessMessage()
+            view.clear()
+        }
+    }
+
+        companion object {
+        const val SPOT_STRING = "18"
+        const val SECURITY_CODE_STRING = "1234"
+        const val SPOT = 18
+        const val SECURITY_CODE = 1234
+    }
+}


### PR DESCRIPTION
This PR contains the whole structure and logic for the spot releasing screen.

- The reservations list was moved to an object in order to be shared among the different models

Release UI
<div style="inline">
<img width="163" alt="image" src="https://github.com/CFedericoDavid/g-reskilling-android-parkingApp/assets/13878290/34aa3868-25d4-4114-8903-04219e3877a5">
<img width="167" alt="image" src="https://github.com/CFedericoDavid/g-reskilling-android-parkingApp/assets/13878290/e20258ca-cc1b-4a22-b45a-a9712b436a71">
</div><br/>

Package structure
<img width="136" alt="image" src="https://github.com/CFedericoDavid/g-reskilling-android-parkingApp/assets/13878290/93a7c858-905d-4902-b4d2-cd4f66dd6e04">

Model tests
<img width="330" alt="image" src="https://github.com/CFedericoDavid/g-reskilling-android-parkingApp/assets/13878290/128a6143-5cc6-4430-8c96-025a947ba985">

Presenter tests
<img width="330" alt="image" src="https://github.com/CFedericoDavid/g-reskilling-android-parkingApp/assets/13878290/66758d57-2710-4a48-8ffc-c57a6b319f61">

Screen Recordings of the app running

https://github.com/CFedericoDavid/g-reskilling-android-parkingApp/assets/13878290/2e9e16d2-588e-4d9b-8c72-7dc5d3b1647c

